### PR TITLE
Fix storj

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,10 @@ RUN if [ "$(arch)" == "x86_64" ];then  export ARCH="amd64";else ARCH="arm64"; fi
     wget $DOWNLOAD_URL/$UPSTREAM_VERSION/identity_linux_${ARCH}.zip && \
     unzip identity_linux_${ARCH}.zip && \
     mv identity /usr/local/bin/identity && \
-    rm identity_linux_${ARCH}.zip
+    rm identity_linux_${ARCH}.zip && \
+    wget $DOWNLOAD_URL/$UPSTREAM_VERSION/storagenode_linux_${ARCH}.zip && \
+    unzip storagenode_linux_${ARCH} && \
+    chmod +x storagenode
 
 COPY entrypoint.sh /usr/bin/
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "storj.public.dappnode.eth",
   "version": "0.0.9",
-  "upstreamVersion": "v1.45.3",
+  "upstreamVersion": "v1.48.2",
   "upstreamRepo": "storj/storj",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Earn tokens by sharing your disk space on the Storj network",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.47.3
+        UPSTREAM_VERSION: v1.48.2
     restart: always
     ports:
       - "28967:28967"


### PR DESCRIPTION
In the last version of the package, the location of the storagenode binary was not found, the path of this binary on the container has not changed but for some reason, this error happened. We have included code in the dockerfile that downloads the binary of the upstream version and adds it to the proper path.

Independent of this error, I think is a good practice because we were using the latest docker image and we had no control of the version of the docker container, now we specify the binaries we will use in this container.